### PR TITLE
Scaffold new registration flow

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -10,7 +10,7 @@ import { HAT_ID } from './constants'
 import { account } from './account'
 
 const app = express()
-const port = 3000
+const port = 3001
 
 // todo: update origin to the frontend domain
 app.use(cors({

--- a/packages/interface/src/features/signup/types.ts
+++ b/packages/interface/src/features/signup/types.ts
@@ -1,6 +1,19 @@
 import type { ReactNode } from "react";
+import { z } from "zod";
 
 export interface FAQItemProps {
   title: string;
   description: ReactNode;
 }
+
+export const EmailSchema = z.object({
+  email: z.string().email()
+});
+
+export type Email = z.infer<typeof EmailSchema>;
+
+export const OtpSchema = z.object({
+  otp: z.number()
+});
+
+export type OTP = z.infer<typeof OtpSchema>;

--- a/packages/interface/src/pages/signup/index.tsx
+++ b/packages/interface/src/pages/signup/index.tsx
@@ -34,14 +34,22 @@ const SignupPage = (): JSX.Element => {
         </Heading>
 
         <p className="flex max-w-screen-md gap-2 text-center text-xl dark:text-gray-400">
-          <span>{config.startsAt && format(config.startsAt, "d MMMM, yyyy")}</span>
+          <span>
+            {config.startsAt && format(config.startsAt, "d MMMM, yyyy")}
+          </span>
 
           <span>-</span>
 
-          <span>{config.resultsAt && format(config.resultsAt, "d MMMM, yyyy")}</span>
+          <span>
+            {config.resultsAt && format(config.resultsAt, "d MMMM, yyyy")}
+          </span>
         </p>
 
-        {!isConnected && <ConnectButton />}
+        <Button size="auto" variant="primary">
+          <Link href="/signup/registerEmail">Register</Link>
+        </Button>
+
+        {/* {!isConnected && <ConnectButton />} */}
 
         {isConnected && appState === EAppState.APPLICATION && (
           <Button size="auto" variant="primary">

--- a/packages/interface/src/pages/signup/registerEmail.tsx
+++ b/packages/interface/src/pages/signup/registerEmail.tsx
@@ -1,0 +1,145 @@
+import { useState } from "react";
+import { useRouter } from "next/router";
+import { format } from "date-fns";
+
+import { EligibilityDialog } from "~/components/EligibilityDialog";
+import { Heading } from "~/components/ui/Heading";
+import { config } from "~/config";
+import { FAQList } from "~/features/signup/components/FaqList";
+import { Layout } from "~/layouts/DefaultLayout";
+import { Form, FormControl, FormSection } from "~/components/ui/Form";
+import { Input } from "~/components/ui/Input";
+import {
+  EmailSchema,
+  Email,
+  OtpSchema,
+  OTP,
+} from "../../features/signup/types";
+import { Button } from "~/components/ui/Button";
+
+const RegisterEmail = (): JSX.Element => {
+  const [otpEmailSent, setOtpEmailSent] = useState(false);
+  const router = useRouter();
+
+  const registerEmail = async (email: Email) => {
+    console.log("OTP has been sent to ", email);
+
+    // TODO: (merge-ok) add this logic after scaffolding flow
+    // const url = "http://localhost:3001/send-otp";
+    // try {
+    //   const response = await fetch(url, {
+    //     method: "POST",
+    //     body: JSON.stringify({ email: email }),
+    //   });
+    //   if (!response.ok) {
+    //     console.log(response.status);
+    //   } else {
+    //     console.log(response);
+    //   }
+    // } catch (error: any) {
+    //   console.error(error);
+    // }
+    setOtpEmailSent(true);
+  };
+
+  const verifyOtp = async (otp: OTP) => {
+    console.log("Verifying OTP: ", otp);
+
+    const account = await generateEmbeddedAccount();
+    await joinSemaporeGroup(account);
+
+    // update state so that other options now show on signup page?
+    router.push("/signup");
+  };
+
+  const generateEmbeddedAccount = async () => {
+    console.log("Generating new account");
+    return "";
+  };
+
+  const joinSemaporeGroup = async (account: string) => {
+    console.log("Joining Semaphore group with account ", account);
+  };
+
+  return (
+    <Layout type="home">
+      <EligibilityDialog />
+
+      <div className="flex h-[90vh] w-screen flex-col items-center justify-center gap-4 bg-blue-50 dark:bg-black">
+        <Heading className="max-w-screen-lg text-center" size="6xl">
+          {config.eventName}
+        </Heading>
+
+        <Heading as="h2" className="max-w-screen-lg text-center" size="4xl">
+          {config.roundId.toUpperCase()}
+        </Heading>
+
+        <p className="flex max-w-screen-md gap-2 text-center text-xl dark:text-gray-400">
+          <span>
+            {config.startsAt && format(config.startsAt, "d MMMM, yyyy")}
+          </span>
+
+          <span>-</span>
+
+          <span>
+            {config.resultsAt && format(config.resultsAt, "d MMMM, yyyy")}
+          </span>
+        </p>
+
+        <Form schema={EmailSchema} onSubmit={(email) => registerEmail(email)}>
+          <FormSection
+            description="Please register with your 'pse.dev' email."
+            title="Register"
+          >
+            <FormControl
+              required
+              hint="This is your 'pse.dev' email address"
+              label="Email address"
+              name="email"
+            >
+              <Input placeholder="bob@pse.dev" />
+            </FormControl>
+            <Button
+              suppressHydrationWarning
+              size="auto"
+              type="submit"
+              variant="primary"
+            >
+              Submit
+            </Button>
+          </FormSection>
+        </Form>
+        {otpEmailSent && (
+          <Form schema={OtpSchema} onSubmit={(otp) => verifyOtp(otp)}>
+            <FormSection
+              description="Please enter the one-time-password (OTP) you recieved in your email"
+              title="Enter OTP"
+            >
+              <FormControl
+                required
+                valueAsNumber
+                hint="Check your 'pse.dev' inbox for the OTP"
+                label="OTP"
+                name="otp"
+              >
+                <Input placeholder="1234" type="number" />
+              </FormControl>
+              <Button
+                suppressHydrationWarning
+                size="auto"
+                type="submit"
+                variant="primary"
+              >
+                Verify OTP
+              </Button>
+            </FormSection>
+          </Form>
+        )}
+      </div>
+
+      <FAQList />
+    </Layout>
+  );
+};
+
+export default RegisterEmail;


### PR DESCRIPTION
This PR:
* Adds a new page to register email addresses and enter OTPs.
* At the moment, the calls to the backend are mocked, along with generating the local account and joining the Semaphore group

 Let me know if you think this shouldn't be a new page, or if something else in the flow should be different, this is just meant to be a starting point from which to iterate from.

Steps to test locally:
1. Add your own address to `NEXT_PUBLIC_ADMIN_ADDRESS`, add `0x78d78209F178d7Cb2a79E48fe504800a0013d496` for `NEXT_PUBLIC_MACI_ADDRESS`, and add your own wallet connect id for `NEXT_PUBLIC_WALLETCONNECT_ID` 
2. `pnpm dev:interface`
3. Click the `REGISTER` button
4. Enter an email address, click `SUBMIT`
5. Enter a number for the OTP, click `Verify OTP`
6. You should get taken back to the login page. Next step isn't added yet. I was thinking here, you would now be able to use the maci frontend as normal. Let me know if anyone has any better ideas 